### PR TITLE
LLM Integration to Translator Service

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ import os
 from flask import Flask
 from flask import request, jsonify
 from src.translator import query_llm_robust
-# from src.translator import get
 
 app = Flask(__name__)
 
@@ -11,7 +10,6 @@ app = Flask(__name__)
 def translator():
     content = request.args.get("content", default = "", type = str)
     is_english, translated_content = query_llm_robust(content)
-    # print(f'is_english: {is_english}, translated_content: {translated_content}')
     return jsonify({
         "is_english": is_english,
         "translated_content": translated_content,

--- a/src/translator.py
+++ b/src/translator.py
@@ -1,20 +1,17 @@
 import openai
 from openai import AzureOpenAI
-# from dotenv import load_dotenv
 import os
 
-# load_dotenv()
-
 client = AzureOpenAI(
-    api_key=os.getenv("API_KEY"),  # Replace with your Azure API key
+    api_key=os.getenv("API_KEY"), 
     api_version="2024-02-15-preview",
-    azure_endpoint="https://p4-tinv1.openai.azure.com/"  # Replace with your Azure endpoint
+    azure_endpoint="https://p4-tinv1.openai.azure.com/"  
 )
 
 def get_language(post: str) -> str:
     context = "The team is implementing a translation feature for NodeBB, a forum that allows instructors and students to make posts. Your task is to classify the language of inputed strings, returning the one-word name of the language in English. All inputs will be consistent in their language throughout, but they can be non-english or in english dialects." 
     response = client.chat.completions.create(
-      model="gpt-4o-mini",  # This should match your deployment name in Azure
+      model="gpt-4o-mini", 
       messages=[
           {
               "role": "system",
@@ -32,7 +29,7 @@ def get_language(post: str) -> str:
 def query_llm_robust(post: str) -> tuple[bool, str]:
   translation_context = "The team is implementing a translation feature for NodeBB, a forum that allows instructors and students to make posts. Your task is to translate the content of English and non-English posts into English and keep all appropriate punctuation and capitalization. For inputs that are non-english strings, you will translate into college-level English. If inputs are in English, return the input. If it does not have translatable meaning, return \"Not Translatable\" ." 
   translation_response = client.chat.completions.create(
-      model="gpt-4o-mini",  # This should match your deployment name in Azure
+      model="gpt-4o-mini", 
       messages=[
           {
               "role": "system",
@@ -47,7 +44,7 @@ def query_llm_robust(post: str) -> tuple[bool, str]:
 
   detection_context = "The team is implementing a translation feature for NodeBB, a forum that allows instructors and students to make posts. Your task is to classify the language of inputed strings, returning the one-word name of the language in English. All inputs will be consistent in their language throughout, but they can be non-english or in english dialects." 
   detection_response = client.chat.completions.create(
-      model="gpt-4o-mini",  # This should match your deployment name in Azure
+      model="gpt-4o-mini", 
       messages=[
           {
               "role": "system",
@@ -68,8 +65,6 @@ def query_llm_robust(post: str) -> tuple[bool, str]:
   if not is_english:
     if translation is None or len(translation) == 0:
       return (False, "Sorry, we are unable to provide an English Translation.")
-    # if len(translation) == 0 and translation_language != "English":
-    #   return (False, "Sorry, we are unable to provide an English Translation.")
     elif "i don't understand your request" in language.lower() or "i don't understand your request" in translation.lower():
       return (False, "Sorry, we are unable to understand the post.")
     elif translation_language is not None and translation_language != "English":
@@ -78,12 +73,3 @@ def query_llm_robust(post: str) -> tuple[bool, str]:
       return (is_english, translation)
   else:
     return (is_english, translation)
-
-#   if language is None or len(language) == 0 or translation is None or len(translation) == 0:
-#     return (False, "Sorry, we are unable to provide a translation at this moment. Please try again later!")
-#   elif "i don't understand your request" in language.lower() or "i don't understand your request" in translation.lower():
-#     return (False, "Sorry, we are unable to understand the post.")
-#   elif translation_language is not None and translation_language != "English":
-#     return (False, "Sorry, we are unable to provide an English Translation.")
-#   else:
-#     return (is_english, translation)

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -1,17 +1,13 @@
 from src.translator import query_llm_robust
-# from unittest.mock import patch
 from mock import patch
 import openai
 from openai import AzureOpenAI
-# from dotenv import load_dotenv
 import os
 
-# load_dotenv()
-
 client = AzureOpenAI(
-    api_key=os.getenv("API_KEY"),  # Replace with your Azure API key
+    api_key=os.getenv("API_KEY"), 
     api_version="2024-02-15-preview",
-    azure_endpoint="https://p4-tinv1.openai.azure.com/"  # Replace with your Azure endpoint
+    azure_endpoint="https://p4-tinv1.openai.azure.com/"  
 )
 
 def test_chinese():
@@ -24,32 +20,17 @@ def test_english():
     assert is_english == True
     assert translated_content == "This is an English message."
 
-# def test_mixed():
-#     is_english, translated_content = query_llm_robust("Hello 世界")
-#     print(f'test_mixed: {translated_content}')
-#     assert is_english == False
-#     assert translated_content == "Hello World"
-
-#pass
 def test_numbers():
     is_english, translated_content = query_llm_robust("12345 世界")
     print(f'test_numbers: {translated_content}')
     assert is_english == False
     assert translated_content.lower() == "12345 world"
 
-#pass
 def test_puncutation():
     is_english, translated_content = query_llm_robust("Hello, how are you?")
     print(f'test_puncutation: {translated_content}')
     assert is_english == True
     assert translated_content == "Hello, how are you?"
-
-#pass
-# def test_emojis():
-#     is_english, translated_content = query_llm_robust("Bonjour 🌟")
-#     # print(f'test_emojis: {translated_content}')
-#     assert is_english == False
-#     assert translated_content == "Hello 🌟"
 
 def test_llm_normal_response():
     is_english, translated_content = query_llm_robust("Bonjour tout le monde")
@@ -65,7 +46,6 @@ def test_llm_gibberish_response():
 
 @patch('src.translator.client.chat.completions.create')
 def test_unexpected_language(mocker):
-  # we mock the model's response to return a random message
   mocker.return_value.choices[0].message.content = "I don't understand your request"
   assert query_llm_robust("Hola, cómo estás.") == (False, "Sorry, we are unable to understand the post.")
 


### PR DESCRIPTION
Updated Translator.py to include OpenAI gpt-4o-mini LLM calls instead of hardcoded responses. Also updated /test/unit/test_translator.py to include mock and unit tests that test gibberish and correct LLM responses.

Acceptance Criteria
- Translator Service is successfully deployed to Azure and usable by NodeBB
- NodeBB translations are no longer hardcoded and adapt to various languages
- All unit and mock tests pass, tests test both correct LLM outputs and incorrect LLM outputs
- The translation service returns certain phrases if the LLM is down or outputs in incorrect tranlation